### PR TITLE
coin instead of page for coingecko

### DIFF
--- a/frontend/app.py
+++ b/frontend/app.py
@@ -62,9 +62,9 @@ async def coinglass(operation: CoinglassOperation, coin: Union[Coins, None] = No
 
 
 @frontend.get("/coingecko")
-async def coingecko(page: Union[int, None] = Query(default=None, ge=1, le=6)):
+async def coingecko(coin: Union[Coins, None] = None):
     redis_key_prefix = "coingecko"
-    if page is None:
-        return await redis_requests(redis_key_prefix, [*range(1, 7)])
+    if coin is None:
+        return await redis_requests(redis_key_prefix, COINS)
     else:
-        return await redis_single_request(redis_key_prefix, page)
+        return await redis_single_request(redis_key_prefix, coin.name)

--- a/updater/app.py
+++ b/updater/app.py
@@ -11,6 +11,7 @@ import logging
 from logging.handlers import QueueListener, QueueHandler
 from logging import StreamHandler
 import sys
+from json import dumps as json_dump
 
 
 SECRET_FILE = "/run/secrets/keys"
@@ -89,7 +90,7 @@ async def _coingeckoRequests(page):
             if response.status == 200:
                 logging.getLogger(__name__).info(
                     "Coingecko request made for {url}".format(url=url))
-                return (page, await response.text())
+                return await response.json()
             else:
                 logging.getLogger(__name__).error(
                     "request to {url} returned code {code}"
@@ -121,8 +122,9 @@ async def _coingecko_runner(redis):
     coingecko_results = await asyncio.gather(*[_coingeckoRequests(p)
                                                for p in range(1, 7)])
     redis.mset({
-        f"coingecko.{page}": body
-        for (page, body) in coingecko_results
+        f"coingecko.{element['symbol'].upper()}": json_dump(element)
+        for body in coingecko_results
+        for element in body
     })
 
 

--- a/updater/app.py
+++ b/updater/app.py
@@ -103,6 +103,7 @@ async def _coingeckoRequests(page):
 
 async def _coinglass_runner(rtype, redis):
 
+    #TODO add coin name/symbol in body
     async def inner(requests):
         results = await asyncio.gather(*requests)
         redis.mset({
@@ -121,8 +122,10 @@ async def _coinglass_runner(rtype, redis):
 async def _coingecko_runner(redis):
     coingecko_results = await asyncio.gather(*[_coingeckoRequests(p)
                                                for p in range(1, 7)])
+    #TODO remove previous keys
+    #TODO save also position of id to keep order
     redis.mset({
-        f"coingecko.{element['symbol'].upper()}": json_dump(element)
+        f"coingecko.{element['id']}": json_dump(element)
         for body in coingecko_results
         for element in body
     })


### PR DESCRIPTION
- [x] change page query to coin query
- [x] check for overlapping symbols (1470 results instead of 1500)
- [x] use all coins for coingecko query
- [ ] order coingecko list as in pages
- [ ] remove previous keys when updating coingecko